### PR TITLE
remove error message

### DIFF
--- a/lib/server/mailchimp.js
+++ b/lib/server/mailchimp.js
@@ -15,8 +15,6 @@ if ( Meteor.settings && Meteor.settings.MailChimpOptions !== undefined &&
 
 	MailChimpOptions.apiKey = Meteor.settings.MailChimpOptions.apiKey;
 	MailChimpOptions.listId = Meteor.settings.MailChimpOptions.listId;
-} else {
-	console.log( '[MailChimp] Error: MailChimp Options have not been set in your settings.json file.' );
 }
 
 MailChimp = function( apiKey, options ) {


### PR DESCRIPTION
Removing error message, to avoid raising an unnecessary error in cases where you pass the API key and list ID manually. 
