### PR TITLE
Refactored bootstrap example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ meteor add miro:mailchimp
 	{{/if}}
 		<div class="form-group">
 			<input class="mailchimp-email form-control" type="email" placeholder="email@example.com"/>
-			<button class="mailchimp-subscribe btn btn-success" type="button">Subscribe</button>
+			<input type="submit" value="Subscribe" class="mailchimp-subscribe btn btn-success" />
 		</div>
 	</form>
 </template>


### PR DESCRIPTION
Refactored bootstrap example form to use `input type="submit"` instead of `button`.

This fixes #32 where page would refresh if user pressed enter after typing in their email address.
