### PR TITLE
Prevent form from submitting on Enter

### DIFF
--- a/lib/client/mailchimp.js
+++ b/lib/client/mailchimp.js
@@ -185,7 +185,7 @@ Meteor.startup( function () {
 			},
 
 			'submit form.form': function ( e ) {
-				event.preventDefault();		// Prevents html form submission
+				e.preventDefault();		// Prevents html form submission
 			},
 
 		});

--- a/lib/client/mailchimp.js
+++ b/lib/client/mailchimp.js
@@ -160,7 +160,7 @@ Meteor.startup( function () {
 						validateEmailAddress( true );
 					}, 0 );
 				}
-			},
+			},			
 
 			'keypress .mailchimp-email': function ( e ) {
 				var key = e.which || e.keyCode || e.charCode;
@@ -182,7 +182,12 @@ Meteor.startup( function () {
 				if ( isValidEmailAddress( subscribeEmail.value  ) ) {
 					subscribeGo( false );
 				}
-			}
+			},
+
+			'submit form.form': function ( e ) {
+				event.preventDefault();		// Prevents html form submission
+			},
+
 		});
 	}
 });


### PR DESCRIPTION
When Enter is pressed the form was submitting in the browser and so it was reloading the page. This prevents the default submit action.

This pull request fixes this issue #41 
